### PR TITLE
Remove serverless offline from dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@movenium/jsonapi-mongodb",
-  "version": "1.1.25",
+  "version": "1.1.26",
   "description": "`npm install @movenium/jsonapi-mongodb --save-dev`",
   "main": "index.js",
   "scripts": {
@@ -16,9 +16,6 @@
     "moment": "^2.30.1",
     "mongodb": "^6.3.0",
     "nyc": "^15.1.0"
-  },
-  "devDependencies": {
-    "serverless-offline": "^13.8.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
The project would not build on NodeJS 16 with the package included.